### PR TITLE
Add more try/catch to report errors to observer 

### DIFF
--- a/test/bigwig.test.ts
+++ b/test/bigwig.test.ts
@@ -176,4 +176,23 @@ describe('bigwig formats', () => {
     expect(feats.slice(-10)).toMatchSnapshot()
     expect(feats.length).toEqual(595)
   })
+
+  it('abort with getFeatures', async () => {
+    const ti = new BigWig({
+      path: require.resolve('./data/volvox.bw'),
+    })
+    const aborter = new HalfAbortController()
+    const ob = ti.getFeatures('ctgA', 0, 100, { signal: aborter.signal })
+    aborter.abort()
+    await expect(ob).rejects.toThrow(/aborted/)
+  })
+  it('abort with getFeatureStream', async () => {
+    const ti = new BigWig({
+      path: require.resolve('./data/volvox.bw'),
+    })
+    const aborter = new HalfAbortController()
+    const ob = await ti.getFeatureStream('ctgA', 0, 100, { signal: aborter.signal })
+    aborter.abort()
+    await expect(ob.toPromise()).rejects.toThrow(/aborted/)
+  })
 })


### PR DESCRIPTION
This proposes to add more try/catch statements to catch errors in the fetching code and to report those to the observer.

I don't know the exact way to explain it but the exceptions that happen within the fetching code don't simply get thrown to the calling stack