### PR TITLE
Use returned buffer from read()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 script:
   - yarn lint
   - yarn test --coverage
+  - yarn build
 cache:
   - yarn
 after_success:

--- a/src/blockView.ts
+++ b/src/blockView.ts
@@ -161,8 +161,6 @@ export class BlockView {
 
   private blockType: string
 
-  private cirTreeBuffer: Buffer
-
   private cirTreePromise?: Promise<{ bytesRead: number; buffer: Buffer }>
 
   private featureCache: any
@@ -194,7 +192,6 @@ export class BlockView {
     this.isBigEndian = isBigEndian
     this.bbi = bbi
     this.blockType = blockType
-    this.cirTreeBuffer = Buffer.alloc(48)
     Object.assign(this, getParsers(isBigEndian))
 
     this.featureCache = new AbortablePromiseCache({
@@ -224,7 +221,7 @@ export class BlockView {
       }
       const request = { chrId, start, end }
       if (!this.cirTreePromise) {
-        this.cirTreePromise = bbi.read(this.cirTreeBuffer, 0, 48, cirTreeOffset, { signal })
+        this.cirTreePromise = bbi.read(Buffer.alloc(48), 0, 48, cirTreeOffset, { signal })
       }
       const { buffer } = await this.cirTreePromise
       const cirBlockSize = isBigEndian ? buffer.readUInt32BE(4) : buffer.readUInt32LE(4)


### PR DESCRIPTION
Same idea as https://github.com/GMOD/bam-js/pull/42: Use the buffer returned from `read()` instead of the one that got passed in.

@cmdcolin note this is a PR into your typescripting branch. Not sure what that needs, but it looks like it'll need to get merged before we can release another version since the current master won't build due to TS errors.