### PR TITLE
reduce the number of header-related reads

### DIFF
--- a/test/bigbed.test.ts
+++ b/test/bigbed.test.ts
@@ -1,6 +1,7 @@
 /* eslint @typescript-eslint/explicit-function-return-type: 0 */
 import BED from '@gmod/bed'
 import { BigBed } from '../src/'
+import { LocalFile } from 'generic-filehandle'
 
 describe('bigbed formats', () => {
   it('loads small bigbed file', async () => {
@@ -17,10 +18,13 @@ describe('bigbed formats', () => {
     expect(lines.slice(0, 5)).toMatchSnapshot()
   })
   it('loads volvox.bb', async () => {
+    const filehandle = new LocalFile(require.resolve('./data/volvox.bb'))
     const ti = new BigBed({
-      path: require.resolve('./data/volvox.bb'),
+      filehandle,
     })
+    const spy = jest.spyOn(filehandle, "read")
     const feats = await ti.getFeatures('chrA', 0, 160)
+    expect(spy.mock.calls.length).toBeLessThanOrEqual(3)
     expect(feats).toEqual([])
   })
   it('searchExtraIdex returns null on file with no extra index', async () => {
@@ -66,10 +70,13 @@ describe('bigbed formats', () => {
     expect(Object.keys(header.refsByName).length).toEqual(2057)
   })
   it('bigbed file with large header', async () => {
+    const filehandle = new LocalFile(require.resolve('./data/clinvarCnv.bb'))
     const ti = new BigBed({
-      path: require.resolve('./data/clinvarCnv.bb'),
+      filehandle,
     })
+    const spy = jest.spyOn(filehandle, "read")
     const header = await ti.getHeader()
+    expect(spy.mock.calls.length).toBeLessThanOrEqual(3);
     expect(header).toBeTruthy()
   })
 })


### PR DESCRIPTION
Hi Colin!  We've never spoken, but from what I've seen, you've been doing a good job.  I like how you've broken things down, like with this repo.

I've been using bbi-js over HTTP, and I've been noticing more requests than I expected in the dev tools.  It's been making multiple requests for the endian check and for the main header read.  Those seem redundant, and they're adding to the latency of the data loads (in my hands, at least).

This change makes fewer header requests by reusing data in the getHeader call chain.  For the "bigbed file with large header" test, the number of reads goes from 11 to 3.  And for the "loads volvox.bb" test, the number of reads goes from 8 to 3.

Also, sort of tangentially, I'd like access to the `definedFieldCount` header in order to interpret BigBed "rest" lines.  I went ahead and included that in this PR since it's just one line but I can split it out if you'd prefer that.