### PR TITLE
perf: optimize `parseBigBedBlock`

### DIFF
--- a/src/block-view.ts
+++ b/src/block-view.ts
@@ -375,7 +375,8 @@ export class BlockView {
     let currOffset = startOffset
     while (currOffset < data.byteLength) {
       const res = this.bigBedParser.parse(data.subarray(currOffset))
-      items.push({ ...res, uniqueId: `bb-${offset + currOffset}` })
+      res.uniqueId = `bb-${offset + currOffset}`
+      items.push(res)
       currOffset += res.offset
     }
 


### PR DESCRIPTION
Hi,

`parseBigBedBlock` makes an unnecessary copy of the object returned by the `bigBedParser.parse`. This improvement may be quite trivial, but still, an unnecessary 50ms in an interactive app contributes a bit to the overall latency :)

Before:
![image](https://github.com/GMOD/bbi-js/assets/399972/f1296a2a-b8e2-4163-ac52-c1bac0849d13)

After:
![image](https://github.com/GMOD/bbi-js/assets/399972/b61d0331-e06f-4574-9200-898543daa4f3)

Context:
I have a pretty large (20GB) bigbed file with >400 columns and a LOT of data to be visualized interactively.