### PR TITLE
Fix bugs in rTreePromise error recovery, _readIndices signal forwarding

### DIFF
--- a/src/array-feature-view.ts
+++ b/src/array-feature-view.ts
@@ -43,8 +43,8 @@ export class ArrayFeatureView {
   public readonly minScores: Float32Array | undefined
   public readonly maxScores: Float32Array | undefined
   public readonly isSummary: boolean
-  private _source: string
-  private _refName: string
+  public readonly source: string
+  public readonly refName: string
 
   constructor(
     arrays: BigWigFeatureArrays | SummaryFeatureArrays,
@@ -57,20 +57,12 @@ export class ArrayFeatureView {
     this.isSummary = arrays.isSummary
     this.minScores = arrays.isSummary ? arrays.minScores : undefined
     this.maxScores = arrays.isSummary ? arrays.maxScores : undefined
-    this._source = source
-    this._refName = refName
+    this.source = source
+    this.refName = refName
   }
 
   get length() {
     return this.starts.length
-  }
-
-  get source() {
-    return this._source
-  }
-
-  get refName() {
-    return this._refName
   }
 
   start(i: number) {
@@ -94,7 +86,7 @@ export class ArrayFeatureView {
   }
 
   id(i: number) {
-    return `${this._source}:${this._refName}:${this.starts[i]}-${this.ends[i]}`
+    return `${this.source}:${this.refName}:${this.starts[i]}-${this.ends[i]}`
   }
 
   get(i: number, key: 'refName' | 'source'): string
@@ -114,9 +106,9 @@ export class ArrayFeatureView {
       case 'score':
         return this.scores[i]
       case 'refName':
-        return this._refName
+        return this.refName
       case 'source':
-        return this._source
+        return this.source
       case 'minScore':
         return this.minScores?.[i]
       case 'maxScore':

--- a/src/bigbed.ts
+++ b/src/bigbed.ts
@@ -176,7 +176,7 @@ export class BigBed extends BBI {
    */
   private async _readIndices(opts: RequestOptions) {
     const { extHeaderOffset } = await this.getHeader(opts)
-    const b = await this.bbi.read(64, extHeaderOffset)
+    const b = await this.bbi.read(64, extHeaderOffset, opts)
 
     const dataView = new DataView(b.buffer, b.byteOffset, b.length)
     const count = dataView.getUint16(2, true)
@@ -189,7 +189,7 @@ export class BigBed extends BBI {
 
     const blocklen = 20
     const len = blocklen * count
-    const buffer = await this.bbi.read(len, dataOffset)
+    const buffer = await this.bbi.read(len, dataOffset, opts)
 
     const indices: Index[] = []
 
@@ -280,7 +280,7 @@ export class BigBed extends BBI {
       if (!f.rest) {
         return false
       }
-      const fieldIndex = (f.field || 0) - 3
+      const fieldIndex = (f.field ?? 0) - 3
       return getTabField(f.rest, fieldIndex) === name
     })
   }

--- a/src/block-view.ts
+++ b/src/block-view.ts
@@ -298,6 +298,25 @@ function parseBigWigBlockAsArrays(
   return { starts, ends, scores }
 }
 
+function parseBlock(
+  blockType: string,
+  data: Uint8Array,
+  blockOffset: number,
+  request?: CoordRequest,
+): Feature[] {
+  switch (blockType) {
+    case 'summary':
+      return parseSummaryBlock(data, 0, request)
+    case 'bigwig':
+      return parseBigWigBlock(data, 0, request)
+    case 'bigbed':
+      return parseBigBedBlock(data, 0, blockOffset * (1 << 8), request)
+    default:
+      console.warn(`Don't know what to do with ${blockType}`)
+      return []
+  }
+}
+
 /**
  * View into a subset of the data in a BigWig file.
  *
@@ -310,7 +329,7 @@ export class BlockView {
   // efficiently query genomic intervals by chromosome and position
   private rTreePromise?: Promise<Uint8Array>
 
-  private featureCache = new AbortablePromiseCache<ReadData, Uint8Array>({
+  private rTreeNodeCache = new AbortablePromiseCache<ReadData, Uint8Array>({
     cache: new QuickLRU({ maxSize: 1000 }),
 
     fill: async ({ length, offset }, signal) =>
@@ -343,7 +362,12 @@ export class BlockView {
       return undefined
     }
     if (!this.rTreePromise) {
-      this.rTreePromise = this.bbi.read(48, this.rTreeOffset, opts)
+      this.rTreePromise = this.bbi
+        .read(48, this.rTreeOffset, opts)
+        .catch((e: unknown) => {
+          this.rTreePromise = undefined
+          throw e
+        })
     }
     const buffer = await this.rTreePromise
     const dataView = new DataView(
@@ -381,7 +405,7 @@ export class BlockView {
       for (const { min, max } of spans) {
         const length = max - min
         const offset = min
-        const resultBuffer = await this.featureCache.get(
+        const resultBuffer = await this.rTreeNodeCache.get(
           `${length}_${offset}`,
           { length, offset },
           opts?.signal,
@@ -486,55 +510,44 @@ export class BlockView {
       const groupOffset = blockGroup.offset
       const subBlocks = blockGroup.blocks
 
-      let decompressedData: Uint8Array
-      let decompressedOffsets: number[]
-
       if (uncompressBufSize > 0) {
-        const localBlocks: { offset: number; length: number }[] = []
-        for (const block of subBlocks) {
-          localBlocks.push({
-            offset: block.offset - groupOffset,
-            length: block.length,
-          })
+        const localBlocks = subBlocks.map(block => ({
+          offset: block.offset - groupOffset,
+          length: block.length,
+        }))
+        const { data: decompressedData, offsets } = await unzipBatch(
+          data,
+          localBlocks,
+          uncompressBufSize,
+        )
+        for (let i = 0; i < subBlocks.length; i++) {
+          const resultData = decompressedData.subarray(
+            offsets[i],
+            offsets[i + 1],
+          )
+          const features = parseBlock(
+            blockType,
+            resultData,
+            subBlocks[i]!.offset,
+            request,
+          )
+          for (const f of features) {
+            allFeatures.push(f)
+          }
         }
-        const result = await unzipBatch(data, localBlocks, uncompressBufSize)
-        decompressedData = result.data
-        decompressedOffsets = result.offsets
       } else {
-        decompressedData = data
-        decompressedOffsets = []
         for (const block of subBlocks) {
-          decompressedOffsets.push(block.offset - groupOffset)
-        }
-        decompressedOffsets.push(data.length)
-      }
-
-      for (let i = 0; i < subBlocks.length; i++) {
-        const start = decompressedOffsets[i]!
-        const end = decompressedOffsets[i + 1]!
-        const resultData = decompressedData.subarray(start, end)
-        let features: Feature[]
-        switch (blockType) {
-          case 'summary':
-            features = parseSummaryBlock(resultData, 0, request)
-            break
-          case 'bigwig':
-            features = parseBigWigBlock(resultData, 0, request)
-            break
-          case 'bigbed':
-            features = parseBigBedBlock(
-              resultData,
-              0,
-              subBlocks[i]!.offset * (1 << 8),
-              request,
-            )
-            break
-          default:
-            features = []
-            console.warn(`Don't know what to do with ${blockType}`)
-        }
-        for (const f of features) {
-          allFeatures.push(f)
+          const start = block.offset - groupOffset
+          const resultData = data.subarray(start, start + block.length)
+          const features = parseBlock(
+            blockType,
+            resultData,
+            block.offset,
+            request,
+          )
+          for (const f of features) {
+            allFeatures.push(f)
+          }
         }
       }
     }

--- a/src/unzip.ts
+++ b/src/unzip.ts
@@ -9,20 +9,23 @@ export interface UnzipBatchResult {
   offsets: number[]
 }
 
-export async function unzipBatch(
-  data: Uint8Array,
-  blocks: { offset: number; length: number }[],
-  maxOutputSize: number,
-): Promise<UnzipBatchResult> {
+function blocksToTypedArrays(blocks: { offset: number; length: number }[]) {
   const inputOffsets = new Uint32Array(blocks.length)
   const inputLengths = new Uint32Array(blocks.length)
-
   for (let i = 0; i < blocks.length; i++) {
     const block = blocks[i]!
     inputOffsets[i] = block.offset
     inputLengths[i] = block.length
   }
+  return { inputOffsets, inputLengths }
+}
 
+export async function unzipBatch(
+  data: Uint8Array,
+  blocks: { offset: number; length: number }[],
+  maxOutputSize: number,
+): Promise<UnzipBatchResult> {
+  const { inputOffsets, inputLengths } = blocksToTypedArrays(blocks)
   return inflateRawBatch(data, inputOffsets, inputLengths, maxOutputSize)
 }
 
@@ -33,15 +36,7 @@ export async function decompressAndParseBigWigBlocks(
   reqStart: number,
   reqEnd: number,
 ) {
-  const inputOffsets = new Uint32Array(blocks.length)
-  const inputLengths = new Uint32Array(blocks.length)
-
-  for (let i = 0; i < blocks.length; i++) {
-    const block = blocks[i]!
-    inputOffsets[i] = block.offset
-    inputLengths[i] = block.length
-  }
-
+  const { inputOffsets, inputLengths } = blocksToTypedArrays(blocks)
   return decompressAndParseBigWig(
     data,
     inputOffsets,
@@ -60,15 +55,7 @@ export async function decompressAndParseSummaryBlocks(
   reqStart: number,
   reqEnd: number,
 ) {
-  const inputOffsets = new Uint32Array(blocks.length)
-  const inputLengths = new Uint32Array(blocks.length)
-
-  for (let i = 0; i < blocks.length; i++) {
-    const block = blocks[i]!
-    inputOffsets[i] = block.offset
-    inputLengths[i] = block.length
-  }
-
+  const { inputOffsets, inputLengths } = blocksToTypedArrays(blocks)
   return decompressAndParseSummary(
     data,
     inputOffsets,

--- a/test/bigbed.test.ts
+++ b/test/bigbed.test.ts
@@ -90,3 +90,18 @@ test('crash', async () => {
   const h = await ti.getHeader()
   expect(h).toMatchSnapshot()
 })
+
+test('_readIndices forwards abort signal to underlying reads', async () => {
+  const filehandle = new LocalFile('test/data/chr22_with_name_index.bb')
+  const ti = new BigBed({ filehandle })
+  await ti.getHeader()
+
+  const aborter = new AbortController()
+  const spy = vi.spyOn(filehandle, 'read')
+
+  await ti.readIndices({ signal: aborter.signal })
+
+  for (const call of spy.mock.calls) {
+    expect(call[2]).toMatchObject({ signal: aborter.signal })
+  }
+})

--- a/test/bigwig.test.ts
+++ b/test/bigwig.test.ts
@@ -1,4 +1,5 @@
-import { expect, test } from 'vitest'
+import { LocalFile } from 'generic-filehandle2'
+import { expect, test, vi } from 'vitest'
 
 import { BigWig } from '../src/index.ts'
 
@@ -169,6 +170,32 @@ test('test uncompressed bw (-unc from wigToBigWig)', async () => {
   const ti = new BigWig({ path: 'test/data/uncompressed.bw' })
   const ob = await ti.getFeatures('ctgA', 40000, 40100)
   expect(ob.slice(0, 10)).toMatchSnapshot()
+})
+
+test('getFeaturesAsArrays matches getFeatures on uncompressed bigwig', async () => {
+  const ti = new BigWig({ path: 'test/data/uncompressed.bw' })
+  const feats = await ti.getFeatures('ctgA', 40000, 40100)
+  const arrays = await ti.getFeaturesAsArrays('ctgA', 40000, 40100)
+  expect(arrays.isSummary).toBe(false)
+  expect(Array.from(arrays.starts)).toEqual(feats.map(f => f.start))
+  expect(Array.from(arrays.ends)).toEqual(feats.map(f => f.end))
+  expect(Array.from(arrays.scores)).toEqual(feats.map(f => f.score))
+})
+
+test('rTreePromise resets after read failure, allowing retry', async () => {
+  const filehandle = new LocalFile('test/data/volvox.bw')
+  const ti = new BigWig({ filehandle })
+  await ti.getHeader()
+
+  const spy = vi
+    .spyOn(filehandle, 'read')
+    .mockImplementationOnce(() => Promise.reject(new Error('network error')))
+
+  await expect(ti.getFeatures('ctgA', 0, 100)).rejects.toThrow('network error')
+
+  spy.mockRestore()
+  const feats = await ti.getFeatures('ctgA', 0, 100)
+  expect(feats.length).toBeGreaterThan(0)
 })
 
 test('crash from bigtools', async () => {


### PR DESCRIPTION
- Allow rTreePromise error recovery
- _readIndices signal forwarding
-  Potential bugfix for 'uncompressed bigwig' reading into block boundaries; refactor for clarity
