### PR TITLE
Add `getFeaturesMulti` for coalesced multi-region queries

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
+          toolchain: stable
           targets: wasm32-unknown-unknown
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: cargo-bins/cargo-binstall@aaa84a43aec4955a42c5ffc65d258961e39f276e # v1.19.1
       - name: Install wasm-bindgen-cli matching Cargo.lock
         run: |
           VERSION=$(grep -A1 '^name = "wasm-bindgen"$' crate/Cargo.lock | grep -oP 'version = "\K[^"]+' | head -1)
@@ -40,10 +41,11 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
+          toolchain: stable
           targets: wasm32-unknown-unknown
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: cargo-bins/cargo-binstall@aaa84a43aec4955a42c5ffc65d258961e39f276e # v1.19.1
       - name: Install wasm-bindgen-cli matching Cargo.lock
         run: |
           VERSION=$(grep -A1 '^name = "wasm-bindgen"$' crate/Cargo.lock | grep -oP 'version = "\K[^"]+' | head -1)

--- a/README.md
+++ b/README.md
@@ -112,34 +112,21 @@ const feats = await bigwig.getFeatures('chr1', 0, 100)
 
 #### getFeaturesMulti(regions, opts)
 
-Fetches features for many regions in a single pass at one zoom level.
-
-- regions - an array of `{ refName, start, end }` objects (same coordinate
-  conventions as getFeatures)
-- opts - same options as getFeatures (scale/basesPerSpan/signal); all regions
-  share one zoom level
-
-Returns a promise to an array of feature arrays, aligned to the input order:
-result `[i]` holds the features for `regions[i]`. An unknown refName yields an
-empty array for that region.
+Fetches features for many regions at once. `regions` is an array of
+`{ refName, start, end }`; `opts` is the same as getFeatures. Returns feature
+arrays aligned to input order (result `[i]` is for `regions[i]`).
 
 ```typescript
 const perRegion = await bigwig.getFeaturesMulti([
   { refName: 'chr1', start: 0, end: 1_000_000 },
   { refName: 'chr2', start: 0, end: 1_000_000 },
 ])
-// perRegion[0] = chr1 features, perRegion[1] = chr2 features
 ```
 
-Why this exists: when a file is laid out in genomic order (standard
-`bedGraphToBigWig`/`bigWigToBigWig` output), blocks for many regions sit
-contiguously on disk. getFeaturesMulti collects the blocks for all regions and
-coalesces physically-adjacent reads across region boundaries into a single
-range request, where calling getFeatures per region issues one request each.
-For a whole-genome overview over a remote file this can collapse one request
-per chromosome into a handful — useful against servers with range-request rate
-limits. Regions may be passed in any order and may overlap; a block shared by
-overlapping regions is fetched once and reported in each region's result.
+Reads for adjacent on-disk blocks are coalesced across region boundaries, so a
+whole-genome overview can use far fewer range requests than calling getFeatures
+per region — handy for rate-limited remote files. Regions may be in any order
+and may overlap.
 
 ### Understanding scale and reductionLevel
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,37 @@ const feats = await bigwig.getFeatures('chr1', 0, 100)
 // note refseq is not returned on the object, it is clearly chr1 from the query though
 ```
 
+#### getFeaturesMulti(regions, opts)
+
+Fetches features for many regions in a single pass at one zoom level.
+
+- regions - an array of `{ refName, start, end }` objects (same coordinate
+  conventions as getFeatures)
+- opts - same options as getFeatures (scale/basesPerSpan/signal); all regions
+  share one zoom level
+
+Returns a promise to an array of feature arrays, aligned to the input order:
+result `[i]` holds the features for `regions[i]`. An unknown refName yields an
+empty array for that region.
+
+```typescript
+const perRegion = await bigwig.getFeaturesMulti([
+  { refName: 'chr1', start: 0, end: 1_000_000 },
+  { refName: 'chr2', start: 0, end: 1_000_000 },
+])
+// perRegion[0] = chr1 features, perRegion[1] = chr2 features
+```
+
+Why this exists: when a file is laid out in genomic order (standard
+`bedGraphToBigWig`/`bigWigToBigWig` output), blocks for many regions sit
+contiguously on disk. getFeaturesMulti collects the blocks for all regions and
+coalesces physically-adjacent reads across region boundaries into a single
+range request, where calling getFeatures per region issues one request each.
+For a whole-genome overview over a remote file this can collapse one request
+per chromosome into a handful — useful against servers with range-request rate
+limits. Regions may be passed in any order and may overlap; a block shared by
+overlapping regions is fetched once and reported in each region's result.
+
 ### Understanding scale and reductionLevel
 
 Here is what the reductionLevel structure looks like in a file. The zoomLevel

--- a/src/bbi.ts
+++ b/src/bbi.ts
@@ -339,6 +339,25 @@ export abstract class BBI {
     )
   }
 
+  /*
+   * Typed-array variant of getFeaturesMulti. Same coalescing across regions,
+   * returning per-region typed arrays aligned to input order.
+   */
+  public async getFeaturesMultiAsArrays(
+    regions: { refName: string; start: number; end: number }[],
+    opts?: RequestOptions2,
+  ): Promise<(BigWigFeatureArrays | SummaryFeatureArrays)[]> {
+    const view = await this._getView(opts)
+    return view.readWigDataMultiAsArrays(
+      regions.map(r => ({
+        refName: this.renameRefSeqs(r.refName),
+        start: r.start,
+        end: r.end,
+      })),
+      opts,
+    )
+  }
+
   public async getFeaturesAsArrays(
     refName: string,
     start: number,

--- a/src/bbi.ts
+++ b/src/bbi.ts
@@ -7,6 +7,7 @@ import type {
   BigWigFeatureArrays,
   BigWigHeader,
   BigWigHeaderWithRefNames,
+  Feature,
   RefInfo,
   RequestOptions2,
   RequestOptions,
@@ -314,6 +315,28 @@ export abstract class BBI {
   ) {
     const view = await this._getView(opts)
     return view.readWigData(this.renameRefSeqs(refName), start, end, opts)
+  }
+
+  /*
+   * Fetch features for many regions at one zoom level in a single pass. All
+   * regions share one view (the zoom level depends on scale, not range), and
+   * blocks across regions are coalesced so adjacent on-disk blocks become one
+   * read. For whole-genome overviews this collapses one-request-per-chromosome
+   * into a handful of reads. Returns features per region, aligned to input.
+   */
+  public async getFeaturesMulti(
+    regions: { refName: string; start: number; end: number }[],
+    opts?: RequestOptions2,
+  ): Promise<Feature[][]> {
+    const view = await this._getView(opts)
+    return view.readWigDataMulti(
+      regions.map(r => ({
+        refName: this.renameRefSeqs(r.refName),
+        start: r.start,
+        end: r.end,
+      })),
+      opts,
+    )
   }
 
   public async getFeaturesAsArrays(

--- a/src/bbi.ts
+++ b/src/bbi.ts
@@ -339,25 +339,6 @@ export abstract class BBI {
     )
   }
 
-  /*
-   * Typed-array variant of getFeaturesMulti. Same coalescing across regions,
-   * returning per-region typed arrays aligned to input order.
-   */
-  public async getFeaturesMultiAsArrays(
-    regions: { refName: string; start: number; end: number }[],
-    opts?: RequestOptions2,
-  ): Promise<(BigWigFeatureArrays | SummaryFeatureArrays)[]> {
-    const view = await this._getView(opts)
-    return view.readWigDataMultiAsArrays(
-      regions.map(r => ({
-        refName: this.renameRefSeqs(r.refName),
-        start: r.start,
-        end: r.end,
-      })),
-      opts,
-    )
-  }
-
   public async getFeaturesAsArrays(
     refName: string,
     start: number,

--- a/src/block-view.ts
+++ b/src/block-view.ts
@@ -525,6 +525,88 @@ export class BlockView {
     })
   }
 
+  // Multi-region read: collect the R-tree blocks for every region, dedupe by
+  // file offset (a block surfaced by overlapping regions is fetched once but
+  // parsed per region), then group the union so physically adjacent blocks
+  // from different regions coalesce into a single read. Each block is tagged
+  // with the region(s) whose coord filter applies when parsing it. Returns
+  // features per region, aligned to the input order.
+  public async readWigDataMulti(
+    regions: { refName: string; start: number; end: number }[],
+    opts: Options = {},
+  ): Promise<Feature[][]> {
+    const results: Feature[][] = regions.map(() => [])
+    const blockByOffset = new Map<number, Block>()
+    const tagsByOffset = new Map<
+      number,
+      { regionIndex: number; request: CoordRequest }[]
+    >()
+    for (let regionIndex = 0; regionIndex < regions.length; regionIndex++) {
+      const { refName, start, end } = regions[regionIndex]!
+      const collected = await this._collectBlocks(refName, start, end, opts)
+      if (collected) {
+        const request = { chrId: collected.chrId, start, end }
+        for (const block of collected.blocks) {
+          const tags = tagsByOffset.get(block.offset)
+          if (tags) {
+            tags.push({ regionIndex, request })
+          } else {
+            blockByOffset.set(block.offset, block)
+            tagsByOffset.set(block.offset, [{ regionIndex, request }])
+          }
+        }
+      }
+    }
+
+    const { blockType, uncompressBufSize } = this
+    const { signal } = opts
+    const parseInto = (resultData: Uint8Array, blockOffset: number) => {
+      const tags = tagsByOffset.get(blockOffset)
+      if (tags) {
+        for (const { regionIndex, request } of tags) {
+          const features = parseBlock(blockType, resultData, blockOffset, request)
+          for (const f of features) {
+            results[regionIndex]!.push(f)
+          }
+        }
+      }
+    }
+
+    for (const blockGroup of groupBlocks([...blockByOffset.values()])) {
+      const data = await this.bbi.read(blockGroup.length, blockGroup.offset, {
+        signal,
+      })
+      const groupOffset = blockGroup.offset
+      const subBlocks = blockGroup.blocks
+
+      if (uncompressBufSize > 0) {
+        const localBlocks = subBlocks.map(block => ({
+          offset: block.offset - groupOffset,
+          length: block.length,
+        }))
+        const { data: decompressedData, offsets } = await unzipBatch(
+          data,
+          localBlocks,
+          uncompressBufSize,
+        )
+        for (let i = 0; i < subBlocks.length; i++) {
+          const resultData = decompressedData.subarray(
+            offsets[i],
+            offsets[i + 1],
+          )
+          parseInto(resultData, subBlocks[i]!.offset)
+        }
+      } else {
+        for (const block of subBlocks) {
+          const start = block.offset - groupOffset
+          const resultData = data.subarray(start, start + block.length)
+          parseInto(resultData, block.offset)
+        }
+      }
+    }
+    return results
+  }
+
   public async readWigDataAsArrays(
     chrName: string,
     start: number,

--- a/src/block-view.ts
+++ b/src/block-view.ts
@@ -525,24 +525,17 @@ export class BlockView {
     })
   }
 
-  // Shared core for multi-region reads. Collects the R-tree blocks for every
-  // region, dedupes by file offset (a block surfaced by overlapping regions is
-  // fetched once but dispatched per region), groups the union so physically
-  // adjacent blocks from different regions coalesce into a single read, then
-  // invokes onBlock with the decompressed bytes once per region tag. The
-  // single-request fused wasm parse can't be used here because one coalesced
-  // group mixes blocks from regions with different coord filters, so blocks are
-  // decompressed in a batch and the per-region parse is left to the callback.
-  private async _eachRegionBlock(
+  // Multi-region read: collect the R-tree blocks for every region, dedupe by
+  // file offset (a block surfaced by overlapping regions is fetched once but
+  // parsed per region), then group the union so physically adjacent blocks
+  // from different regions coalesce into a single read. Each block is tagged
+  // with the region(s) whose coord filter applies when parsing it. Returns
+  // features per region, aligned to the input order.
+  public async readWigDataMulti(
     regions: { refName: string; start: number; end: number }[],
-    opts: Options,
-    onBlock: (
-      data: Uint8Array,
-      blockOffset: number,
-      regionIndex: number,
-      request: CoordRequest,
-    ) => void,
-  ): Promise<void> {
+    opts: Options = {},
+  ): Promise<Feature[][]> {
+    const results: Feature[][] = regions.map(() => [])
     const blockByOffset = new Map<number, Block>()
     const tagsByOffset = new Map<
       number,
@@ -565,12 +558,16 @@ export class BlockView {
       }
     }
 
+    const { blockType, uncompressBufSize } = this
     const { signal } = opts
-    const dispatch = (resultData: Uint8Array, blockOffset: number) => {
+    const parseInto = (resultData: Uint8Array, blockOffset: number) => {
       const tags = tagsByOffset.get(blockOffset)
       if (tags) {
         for (const { regionIndex, request } of tags) {
-          onBlock(resultData, blockOffset, regionIndex, request)
+          const features = parseBlock(blockType, resultData, blockOffset, request)
+          for (const f of features) {
+            results[regionIndex]!.push(f)
+          }
         }
       }
     }
@@ -582,7 +579,7 @@ export class BlockView {
       const groupOffset = blockGroup.offset
       const subBlocks = blockGroup.blocks
 
-      if (this.uncompressBufSize > 0) {
+      if (uncompressBufSize > 0) {
         const localBlocks = subBlocks.map(block => ({
           offset: block.offset - groupOffset,
           length: block.length,
@@ -590,114 +587,24 @@ export class BlockView {
         const { data: decompressedData, offsets } = await unzipBatch(
           data,
           localBlocks,
-          this.uncompressBufSize,
+          uncompressBufSize,
         )
         for (let i = 0; i < subBlocks.length; i++) {
-          dispatch(
-            decompressedData.subarray(offsets[i], offsets[i + 1]),
-            subBlocks[i]!.offset,
+          const resultData = decompressedData.subarray(
+            offsets[i],
+            offsets[i + 1],
           )
+          parseInto(resultData, subBlocks[i]!.offset)
         }
       } else {
         for (const block of subBlocks) {
           const start = block.offset - groupOffset
-          dispatch(data.subarray(start, start + block.length), block.offset)
+          const resultData = data.subarray(start, start + block.length)
+          parseInto(resultData, block.offset)
         }
       }
     }
-  }
-
-  // Multi-region read returning features per region, aligned to input order.
-  public async readWigDataMulti(
-    regions: { refName: string; start: number; end: number }[],
-    opts: Options = {},
-  ): Promise<Feature[][]> {
-    const { blockType } = this
-    const results: Feature[][] = regions.map(() => [])
-    await this._eachRegionBlock(
-      regions,
-      opts,
-      (data, blockOffset, regionIndex, request) => {
-        for (const f of parseBlock(blockType, data, blockOffset, request)) {
-          results[regionIndex]!.push(f)
-        }
-      },
-    )
     return results
-  }
-
-  // Multi-region read returning typed-array features per region, aligned to
-  // input order. blockType is fixed per view, so every region yields the same
-  // shape (all summary or all bigwig).
-  public async readWigDataMultiAsArrays(
-    regions: { refName: string; start: number; end: number }[],
-    opts: Options = {},
-  ): Promise<(BigWigFeatureArrays | SummaryFeatureArrays)[]> {
-    const isSummary = this.blockType === 'summary'
-    const bwChunks: ReturnType<typeof parseBigWigBlockAsArrays>[][] =
-      regions.map(() => [])
-    const sumChunks: ReturnType<typeof parseSummaryBlockAsArrays>[][] =
-      regions.map(() => [])
-    await this._eachRegionBlock(
-      regions,
-      opts,
-      (data, _blockOffset, regionIndex, request) => {
-        if (isSummary) {
-          const chunk = parseSummaryBlockAsArrays(data, request)
-          if (chunk.starts.length > 0) {
-            sumChunks[regionIndex]!.push(chunk)
-          }
-        } else {
-          const chunk = parseBigWigBlockAsArrays(data, request)
-          if (chunk.starts.length > 0) {
-            bwChunks[regionIndex]!.push(chunk)
-          }
-        }
-      },
-    )
-
-    return regions.map((_, i) => {
-      if (isSummary) {
-        const chunks = sumChunks[i]!
-        const total = chunks.reduce((n, c) => n + c.starts.length, 0)
-        return {
-          starts: concatTypedArray(
-            chunks.map(c => c.starts),
-            total,
-            Int32Array,
-          ),
-          ends: concatTypedArray(chunks.map(c => c.ends), total, Int32Array),
-          scores: concatTypedArray(
-            chunks.map(c => c.scores),
-            total,
-            Float32Array,
-          ),
-          minScores: concatTypedArray(
-            chunks.map(c => c.minScores),
-            total,
-            Float32Array,
-          ),
-          maxScores: concatTypedArray(
-            chunks.map(c => c.maxScores),
-            total,
-            Float32Array,
-          ),
-          isSummary: true as const,
-        }
-      }
-      const chunks = bwChunks[i]!
-      const total = chunks.reduce((n, c) => n + c.starts.length, 0)
-      return {
-        starts: concatTypedArray(chunks.map(c => c.starts), total, Int32Array),
-        ends: concatTypedArray(chunks.map(c => c.ends), total, Int32Array),
-        scores: concatTypedArray(
-          chunks.map(c => c.scores),
-          total,
-          Float32Array,
-        ),
-        isSummary: false as const,
-      }
-    })
   }
 
   public async readWigDataAsArrays(

--- a/src/block-view.ts
+++ b/src/block-view.ts
@@ -525,17 +525,24 @@ export class BlockView {
     })
   }
 
-  // Multi-region read: collect the R-tree blocks for every region, dedupe by
-  // file offset (a block surfaced by overlapping regions is fetched once but
-  // parsed per region), then group the union so physically adjacent blocks
-  // from different regions coalesce into a single read. Each block is tagged
-  // with the region(s) whose coord filter applies when parsing it. Returns
-  // features per region, aligned to the input order.
-  public async readWigDataMulti(
+  // Shared core for multi-region reads. Collects the R-tree blocks for every
+  // region, dedupes by file offset (a block surfaced by overlapping regions is
+  // fetched once but dispatched per region), groups the union so physically
+  // adjacent blocks from different regions coalesce into a single read, then
+  // invokes onBlock with the decompressed bytes once per region tag. The
+  // single-request fused wasm parse can't be used here because one coalesced
+  // group mixes blocks from regions with different coord filters, so blocks are
+  // decompressed in a batch and the per-region parse is left to the callback.
+  private async _eachRegionBlock(
     regions: { refName: string; start: number; end: number }[],
-    opts: Options = {},
-  ): Promise<Feature[][]> {
-    const results: Feature[][] = regions.map(() => [])
+    opts: Options,
+    onBlock: (
+      data: Uint8Array,
+      blockOffset: number,
+      regionIndex: number,
+      request: CoordRequest,
+    ) => void,
+  ): Promise<void> {
     const blockByOffset = new Map<number, Block>()
     const tagsByOffset = new Map<
       number,
@@ -558,16 +565,12 @@ export class BlockView {
       }
     }
 
-    const { blockType, uncompressBufSize } = this
     const { signal } = opts
-    const parseInto = (resultData: Uint8Array, blockOffset: number) => {
+    const dispatch = (resultData: Uint8Array, blockOffset: number) => {
       const tags = tagsByOffset.get(blockOffset)
       if (tags) {
         for (const { regionIndex, request } of tags) {
-          const features = parseBlock(blockType, resultData, blockOffset, request)
-          for (const f of features) {
-            results[regionIndex]!.push(f)
-          }
+          onBlock(resultData, blockOffset, regionIndex, request)
         }
       }
     }
@@ -579,7 +582,7 @@ export class BlockView {
       const groupOffset = blockGroup.offset
       const subBlocks = blockGroup.blocks
 
-      if (uncompressBufSize > 0) {
+      if (this.uncompressBufSize > 0) {
         const localBlocks = subBlocks.map(block => ({
           offset: block.offset - groupOffset,
           length: block.length,
@@ -587,24 +590,114 @@ export class BlockView {
         const { data: decompressedData, offsets } = await unzipBatch(
           data,
           localBlocks,
-          uncompressBufSize,
+          this.uncompressBufSize,
         )
         for (let i = 0; i < subBlocks.length; i++) {
-          const resultData = decompressedData.subarray(
-            offsets[i],
-            offsets[i + 1],
+          dispatch(
+            decompressedData.subarray(offsets[i], offsets[i + 1]),
+            subBlocks[i]!.offset,
           )
-          parseInto(resultData, subBlocks[i]!.offset)
         }
       } else {
         for (const block of subBlocks) {
           const start = block.offset - groupOffset
-          const resultData = data.subarray(start, start + block.length)
-          parseInto(resultData, block.offset)
+          dispatch(data.subarray(start, start + block.length), block.offset)
         }
       }
     }
+  }
+
+  // Multi-region read returning features per region, aligned to input order.
+  public async readWigDataMulti(
+    regions: { refName: string; start: number; end: number }[],
+    opts: Options = {},
+  ): Promise<Feature[][]> {
+    const { blockType } = this
+    const results: Feature[][] = regions.map(() => [])
+    await this._eachRegionBlock(
+      regions,
+      opts,
+      (data, blockOffset, regionIndex, request) => {
+        for (const f of parseBlock(blockType, data, blockOffset, request)) {
+          results[regionIndex]!.push(f)
+        }
+      },
+    )
     return results
+  }
+
+  // Multi-region read returning typed-array features per region, aligned to
+  // input order. blockType is fixed per view, so every region yields the same
+  // shape (all summary or all bigwig).
+  public async readWigDataMultiAsArrays(
+    regions: { refName: string; start: number; end: number }[],
+    opts: Options = {},
+  ): Promise<(BigWigFeatureArrays | SummaryFeatureArrays)[]> {
+    const isSummary = this.blockType === 'summary'
+    const bwChunks: ReturnType<typeof parseBigWigBlockAsArrays>[][] =
+      regions.map(() => [])
+    const sumChunks: ReturnType<typeof parseSummaryBlockAsArrays>[][] =
+      regions.map(() => [])
+    await this._eachRegionBlock(
+      regions,
+      opts,
+      (data, _blockOffset, regionIndex, request) => {
+        if (isSummary) {
+          const chunk = parseSummaryBlockAsArrays(data, request)
+          if (chunk.starts.length > 0) {
+            sumChunks[regionIndex]!.push(chunk)
+          }
+        } else {
+          const chunk = parseBigWigBlockAsArrays(data, request)
+          if (chunk.starts.length > 0) {
+            bwChunks[regionIndex]!.push(chunk)
+          }
+        }
+      },
+    )
+
+    return regions.map((_, i) => {
+      if (isSummary) {
+        const chunks = sumChunks[i]!
+        const total = chunks.reduce((n, c) => n + c.starts.length, 0)
+        return {
+          starts: concatTypedArray(
+            chunks.map(c => c.starts),
+            total,
+            Int32Array,
+          ),
+          ends: concatTypedArray(chunks.map(c => c.ends), total, Int32Array),
+          scores: concatTypedArray(
+            chunks.map(c => c.scores),
+            total,
+            Float32Array,
+          ),
+          minScores: concatTypedArray(
+            chunks.map(c => c.minScores),
+            total,
+            Float32Array,
+          ),
+          maxScores: concatTypedArray(
+            chunks.map(c => c.maxScores),
+            total,
+            Float32Array,
+          ),
+          isSummary: true as const,
+        }
+      }
+      const chunks = bwChunks[i]!
+      const total = chunks.reduce((n, c) => n + c.starts.length, 0)
+      return {
+        starts: concatTypedArray(chunks.map(c => c.starts), total, Int32Array),
+        ends: concatTypedArray(chunks.map(c => c.ends), total, Int32Array),
+        scores: concatTypedArray(
+          chunks.map(c => c.scores),
+          total,
+          Float32Array,
+        ),
+        isSummary: false as const,
+      }
+    })
   }
 
   public async readWigDataAsArrays(

--- a/test/multi.test.ts
+++ b/test/multi.test.ts
@@ -1,0 +1,118 @@
+import { LocalFile } from 'generic-filehandle2'
+import { expect, test } from 'vitest'
+
+import { BigWig } from '../src/index.ts'
+
+import type { GenericFilehandle } from 'generic-filehandle2'
+
+// wraps a filehandle to count read() calls so we can assert that multi-region
+// queries coalesce on-disk-adjacent blocks into fewer reads
+class CountingFile {
+  reads = 0
+  bytes = 0
+  offsets: number[] = []
+  constructor(private inner: GenericFilehandle) {}
+  read(length: number, position: number, opts?: Record<string, unknown>) {
+    this.reads++
+    this.bytes += length
+    this.offsets.push(position)
+    return this.inner.read(length, position, opts)
+  }
+  readFile(opts?: Record<string, unknown>) {
+    return this.inner.readFile(opts)
+  }
+  stat() {
+    return this.inner.stat()
+  }
+  close() {
+    return Promise.resolve()
+  }
+}
+
+test('getFeaturesMulti matches per-region getFeatures', async () => {
+  const bw = new BigWig({ path: 'test/data/cDC.bw' })
+  const header = await bw.getHeader()
+  const regions = (Object.values(header.refsByNumber) as { name: string; length: number }[]).map(
+    r => ({ refName: r.name, start: 0, end: r.length }),
+  )
+  const scale = 1000 / 250_000_000
+
+  const multi = await bw.getFeaturesMulti(regions, { scale })
+  const loop = []
+  for (const r of regions) {
+    loop.push(await bw.getFeatures(r.refName, r.start, r.end, { scale }))
+  }
+
+  expect(multi.length).toBe(regions.length)
+  for (let i = 0; i < regions.length; i++) {
+    expect(multi[i]).toStrictEqual(loop[i])
+  }
+})
+
+test('getFeaturesMulti coalesces whole-genome reads', async () => {
+  const fhLoop = new CountingFile(new LocalFile('test/data/cDC.bw'))
+  const bwLoop = new BigWig({ filehandle: fhLoop })
+  const headerLoop = await bwLoop.getHeader()
+  const regions = (
+    Object.values(headerLoop.refsByNumber) as { name: string; length: number }[]
+  ).map(r => ({ refName: r.name, start: 0, end: r.length }))
+  const scale = 1000 / 250_000_000
+
+  const afterHeaderLoop = fhLoop.reads
+  for (const r of regions) {
+    await bwLoop.getFeatures(r.refName, r.start, r.end, { scale })
+  }
+  const loopReads = fhLoop.reads - afterHeaderLoop
+
+  const fhMulti = new CountingFile(new LocalFile('test/data/cDC.bw'))
+  const bwMulti = new BigWig({ filehandle: fhMulti })
+  await bwMulti.getHeader()
+  const afterHeaderMulti = fhMulti.reads
+  await bwMulti.getFeaturesMulti(regions, { scale })
+  const multiReads = fhMulti.reads - afterHeaderMulti
+
+  // multi-region must issue strictly fewer reads for a whole-genome overview
+  expect(multiReads).toBeLessThan(loopReads)
+  // and the per-chromosome loop should issue at least ~1 read per chromosome
+  expect(loopReads).toBeGreaterThanOrEqual(regions.length)
+})
+
+test('getFeaturesMulti handles overlapping regions without double-fetch', async () => {
+  const fh = new CountingFile(new LocalFile('test/data/cDC.bw'))
+  const bw = new BigWig({ filehandle: fh })
+  await bw.getHeader()
+  const regions = [
+    { refName: 'chr1', start: 1_000_000, end: 3_000_000 },
+    { refName: 'chr1', start: 2_000_000, end: 4_000_000 }, // overlaps previous
+    { refName: 'chr2', start: 0, end: 5_000_000 },
+  ]
+  const scale = 1 / 5000
+
+  const offsetsBefore = fh.offsets.length
+  const multi = await bw.getFeaturesMulti(regions, { scale })
+  const multiOffsets = fh.offsets.slice(offsetsBefore)
+
+  // each region bucket must equal an independent getFeatures for that region
+  for (let i = 0; i < regions.length; i++) {
+    const r = regions[i]!
+    const truth = await bw.getFeatures(r.refName, r.start, r.end, { scale })
+    expect(multi[i]).toStrictEqual(truth)
+  }
+  // a block shared by the two overlapping regions is fetched once, not twice
+  expect(new Set(multiOffsets).size).toBe(multiOffsets.length)
+})
+
+test('getFeaturesMulti handles unknown refName and empty input', async () => {
+  const bw = new BigWig({ path: 'test/data/cDC.bw' })
+  const scale = 1 / 1000
+  const res = await bw.getFeaturesMulti(
+    [
+      { refName: 'chr1', start: 0, end: 100000 },
+      { refName: 'nonexistent', start: 0, end: 100 },
+    ],
+    { scale },
+  )
+  expect(res.length).toBe(2)
+  expect(res[1]).toStrictEqual([])
+  expect(await bw.getFeaturesMulti([], { scale })).toStrictEqual([])
+})

--- a/test/multi.test.ts
+++ b/test/multi.test.ts
@@ -144,6 +144,43 @@ test('getFeaturesMulti is order-independent', async () => {
   expect(fhSorted.reads - beforeSorted).toBe(scrambledReads)
 })
 
+test.each([
+  ['summary zoom', 1 / 20000],
+  ['base level', 1],
+])('getFeaturesMultiAsArrays matches per-region (%s)', async (_label, scale) => {
+  const bw = new BigWig({ path: 'test/data/cDC.bw' })
+  const regions = [
+    { refName: 'chr1', start: 1_000_000, end: 3_000_000 },
+    { refName: 'chr2', start: 0, end: 5_000_000 },
+    { refName: 'chr1', start: 2_000_000, end: 4_000_000 }, // overlaps region 0
+  ]
+  const multi = await bw.getFeaturesMultiAsArrays(regions, { scale })
+  expect(multi.length).toBe(regions.length)
+  for (let i = 0; i < regions.length; i++) {
+    const r = regions[i]!
+    const truth = await bw.getFeaturesAsArrays(r.refName, r.start, r.end, {
+      scale,
+    })
+    expect(multi[i]).toStrictEqual(truth)
+  }
+})
+
+test('getFeaturesMultiAsArrays handles unknown refName and empty input', async () => {
+  const bw = new BigWig({ path: 'test/data/cDC.bw' })
+  const res = await bw.getFeaturesMultiAsArrays(
+    [
+      { refName: 'chr1', start: 0, end: 100000 },
+      { refName: 'nonexistent', start: 0, end: 100 },
+    ],
+    { scale: 1 },
+  )
+  expect(res.length).toBe(2)
+  expect(res[1]!.starts.length).toBe(0)
+  expect(res[1]!.ends.length).toBe(0)
+  expect(res[1]!.scores.length).toBe(0)
+  expect(await bw.getFeaturesMultiAsArrays([], { scale: 1 })).toStrictEqual([])
+})
+
 test('getFeaturesMulti handles unknown refName and empty input', async () => {
   const bw = new BigWig({ path: 'test/data/cDC.bw' })
   const scale = 1 / 1000

--- a/test/multi.test.ts
+++ b/test/multi.test.ts
@@ -144,43 +144,6 @@ test('getFeaturesMulti is order-independent', async () => {
   expect(fhSorted.reads - beforeSorted).toBe(scrambledReads)
 })
 
-test.each([
-  ['summary zoom', 1 / 20000],
-  ['base level', 1],
-])('getFeaturesMultiAsArrays matches per-region (%s)', async (_label, scale) => {
-  const bw = new BigWig({ path: 'test/data/cDC.bw' })
-  const regions = [
-    { refName: 'chr1', start: 1_000_000, end: 3_000_000 },
-    { refName: 'chr2', start: 0, end: 5_000_000 },
-    { refName: 'chr1', start: 2_000_000, end: 4_000_000 }, // overlaps region 0
-  ]
-  const multi = await bw.getFeaturesMultiAsArrays(regions, { scale })
-  expect(multi.length).toBe(regions.length)
-  for (let i = 0; i < regions.length; i++) {
-    const r = regions[i]!
-    const truth = await bw.getFeaturesAsArrays(r.refName, r.start, r.end, {
-      scale,
-    })
-    expect(multi[i]).toStrictEqual(truth)
-  }
-})
-
-test('getFeaturesMultiAsArrays handles unknown refName and empty input', async () => {
-  const bw = new BigWig({ path: 'test/data/cDC.bw' })
-  const res = await bw.getFeaturesMultiAsArrays(
-    [
-      { refName: 'chr1', start: 0, end: 100000 },
-      { refName: 'nonexistent', start: 0, end: 100 },
-    ],
-    { scale: 1 },
-  )
-  expect(res.length).toBe(2)
-  expect(res[1]!.starts.length).toBe(0)
-  expect(res[1]!.ends.length).toBe(0)
-  expect(res[1]!.scores.length).toBe(0)
-  expect(await bw.getFeaturesMultiAsArrays([], { scale: 1 })).toStrictEqual([])
-})
-
 test('getFeaturesMulti handles unknown refName and empty input', async () => {
   const bw = new BigWig({ path: 'test/data/cDC.bw' })
   const scale = 1 / 1000

--- a/test/multi.test.ts
+++ b/test/multi.test.ts
@@ -102,6 +102,48 @@ test('getFeaturesMulti handles overlapping regions without double-fetch', async 
   expect(new Set(multiOffsets).size).toBe(multiOffsets.length)
 })
 
+test('getFeaturesMulti is order-independent', async () => {
+  const bw = new BigWig({ path: 'test/data/cDC.bw' })
+  const scale = 1 / 20000
+  // scrambled chromosome order plus a non-monotonic same-chrom pair
+  const regions = [
+    { refName: 'chr5', start: 10_000_000, end: 20_000_000 },
+    { refName: 'chr1', start: 50_000_000, end: 60_000_000 },
+    { refName: 'chr1', start: 0, end: 10_000_000 },
+    { refName: 'chr22', start: 1_000_000, end: 5_000_000 },
+    { refName: 'chr2', start: 30_000_000, end: 40_000_000 },
+  ]
+
+  const fhScrambled = new CountingFile(new LocalFile('test/data/cDC.bw'))
+  const bwScrambled = new BigWig({ filehandle: fhScrambled })
+  await bwScrambled.getHeader()
+  const before = fhScrambled.reads
+  const multi = await bwScrambled.getFeaturesMulti(regions, { scale })
+  const scrambledReads = fhScrambled.reads - before
+
+  // buckets stay aligned to input order and match independent getFeatures
+  for (let i = 0; i < regions.length; i++) {
+    const r = regions[i]!
+    expect(multi[i]).toStrictEqual(
+      await bw.getFeatures(r.refName, r.start, r.end, { scale }),
+    )
+  }
+
+  // coalescing depends only on file offset, so pre-sorting the input must not
+  // change the number of reads
+  const sorted = [...regions].sort((a, b) =>
+    a.refName === b.refName
+      ? a.start - b.start
+      : a.refName.localeCompare(b.refName),
+  )
+  const fhSorted = new CountingFile(new LocalFile('test/data/cDC.bw'))
+  const bwSorted = new BigWig({ filehandle: fhSorted })
+  await bwSorted.getHeader()
+  const beforeSorted = fhSorted.reads
+  await bwSorted.getFeaturesMulti(sorted, { scale })
+  expect(fhSorted.reads - beforeSorted).toBe(scrambledReads)
+})
+
 test('getFeaturesMulti handles unknown refName and empty input', async () => {
   const bw = new BigWig({ path: 'test/data/cDC.bw' })
   const scale = 1 / 1000


### PR DESCRIPTION
getFeaturesMulti(regions, opts) collects R-tree blocks across all regions into one view, dedupes by file offset, and groups the union so on-disk adjacent blocks from different chromosomes coalesce into a single read. Each block is tagged with the region coord filter(s) that apply when parsing, so results are returned per-region aligned to input order.

For whole-genome overviews at a high zoom level this collapses one-request-per-chromosome into a handful of reads. Measured against remote colo829 (hg19, 25 chroms): 27 reads/691KB -> 3 reads/312KB with byte-identical features; the dropped bytes are redundant overlapping R-tree node re-reads, not data.


help address #83