### PR TITLE
feat: add getFeaturesAsArraysMulti for multi-region typed-array reads

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,6 +36,7 @@ export default defineConfig(
   eslintPluginUnicorn.configs.recommended,
   {
     rules: {
+      '@typescript-eslint/parameter-properties': 'error',
       '@typescript-eslint/no-unused-vars': [
         'warn',
         {

--- a/src/array-feature-view.ts
+++ b/src/array-feature-view.ts
@@ -8,10 +8,13 @@ import type { BigWigFeatureArrays, SummaryFeatureArrays } from './types.ts'
  * `summary`, `minScore`, `maxScore`.
  */
 export class BigWigFeature {
-  constructor(
-    private view: ArrayFeatureView,
-    private i: number,
-  ) {}
+  private view: ArrayFeatureView
+  private i: number
+
+  constructor(view: ArrayFeatureView, i: number) {
+    this.view = view
+    this.i = i
+  }
 
   /** @internal */
   get(key: 'refName' | 'source'): string

--- a/src/bbi.ts
+++ b/src/bbi.ts
@@ -5,6 +5,7 @@ import { decoder, getDataView, parseKey } from './util.ts'
 
 import type {
   BigWigFeatureArrays,
+  BigWigFeatureArraysMulti,
   BigWigHeader,
   BigWigHeaderWithRefNames,
   Feature,
@@ -13,6 +14,7 @@ import type {
   RequestOptions,
   Statistics,
   SummaryFeatureArrays,
+  SummaryFeatureArraysMulti,
   ZoomLevel,
 } from './types.ts'
 import type { GenericFilehandle } from 'generic-filehandle2'
@@ -377,6 +379,33 @@ export abstract class BBI {
       this.renameRefSeqs(refName),
       start,
       end,
+      opts,
+    )
+  }
+
+  /**
+   * Multi-region counterpart of `getFeaturesAsArrays`. All regions share one
+   * zoom level and adjacent on-disk blocks coalesce across region boundaries
+   * (like `getFeaturesMulti`), but results pack into one backing set of typed
+   * arrays instead of one object per region, minimizing allocations.
+   *
+   * @param regions - array of `{ refName, start, end }` query regions
+   * @param opts - same options as `getFeatures`
+   * @returns `Promise<BigWigFeatureArraysMulti | SummaryFeatureArraysMulti>` —
+   *   use the `isSummary` discriminant to distinguish the two shapes; slice
+   *   region `i` with `regionOffsets[i]..regionOffsets[i + 1]`
+   */
+  public async getFeaturesAsArraysMulti(
+    regions: { refName: string; start: number; end: number }[],
+    opts?: RequestOptions2,
+  ): Promise<BigWigFeatureArraysMulti | SummaryFeatureArraysMulti> {
+    const view = await this._getView(opts)
+    return view.readWigDataAsArraysMulti(
+      regions.map(r => ({
+        refName: this.renameRefSeqs(r.refName),
+        start: r.start,
+        end: r.end,
+      })),
       opts,
     )
   }

--- a/src/bigwig.ts
+++ b/src/bigwig.ts
@@ -4,7 +4,8 @@ import type { RequestOptions } from './types.ts'
 
 /**
  * Parser for BigWig files. Inherits `getHeader`, `getFeatures`,
- * `getFeaturesMulti`, and `getFeaturesAsArrays` from `BBI`.
+ * `getFeaturesMulti`, `getFeaturesAsArrays`, and `getFeaturesAsArraysMulti`
+ * from `BBI`.
  *
  * Supports zoom levels — pass `opts.scale` or `opts.basesPerSpan` to
  * automatically select the appropriate pre-computed zoom level.

--- a/src/block-view.ts
+++ b/src/block-view.ts
@@ -414,19 +414,30 @@ export class BlockView {
       this.bbi.read(length, offset, { signal }),
   })
 
+  private bbi: GenericFilehandle
+  private refsByName: Record<string, number>
+  // Offset to the R-tree index in the file - this is part of the "cirTree"
+  // (combined ID R-tree), which combines a B+ tree for chromosome names
+  // with an R-tree for efficient spatial queries
+  private rTreeOffset: number
+  private uncompressBufSize: number
+  private blockType: string
+
   public constructor(
-    private bbi: GenericFilehandle,
-    private refsByName: Record<string, number>,
-    // Offset to the R-tree index in the file - this is part of the "cirTree"
-    // (combined ID R-tree), which combines a B+ tree for chromosome names
-    // with an R-tree for efficient spatial queries
-    private rTreeOffset: number,
-    private uncompressBufSize: number,
-    private blockType: string,
+    bbi: GenericFilehandle,
+    refsByName: Record<string, number>,
+    rTreeOffset: number,
+    uncompressBufSize: number,
+    blockType: string,
   ) {
     if (!(rTreeOffset >= 0)) {
       throw new Error('invalid rTreeOffset!')
     }
+    this.bbi = bbi
+    this.refsByName = refsByName
+    this.rTreeOffset = rTreeOffset
+    this.uncompressBufSize = uncompressBufSize
+    this.blockType = blockType
   }
 
   private async _collectBlocks(

--- a/src/block-view.ts
+++ b/src/block-view.ts
@@ -10,7 +10,12 @@ import {
 import { decoder, getDataView, groupBlocks } from './util.ts'
 
 import type { Feature, ProgressCallback } from './types.ts'
-import type { BigWigFeatureArrays, SummaryFeatureArrays } from './unzip.ts'
+import type {
+  BigWigFeatureArrays,
+  BigWigFeatureArraysMulti,
+  SummaryFeatureArrays,
+  SummaryFeatureArraysMulti,
+} from './unzip.ts'
 import type { Block } from './util.ts'
 import type { GenericFilehandle } from 'generic-filehandle2'
 
@@ -20,6 +25,19 @@ interface CoordRequest {
   chrId: number
   start: number
   end: number
+}
+
+// One block can serve several query regions (overlapping ranges surface the
+// same on-disk block). Each tag records which region wants the block and the
+// coord filter to apply when parsing it for that region.
+interface RegionTag {
+  regionIndex: number
+  request: CoordRequest
+}
+
+interface CollectedBlocksMulti {
+  blockByOffset: Map<number, Block>
+  tagsByOffset: Map<number, RegionTag[]>
 }
 
 interface Options {
@@ -376,6 +394,134 @@ function concatTypedArray<T extends Int32Array | Float32Array>(
   return out
 }
 
+interface BigWigChunk { starts: Int32Array; ends: Int32Array; scores: Float32Array }
+type SummaryChunk = BigWigChunk & {
+  minScores: Float32Array
+  maxScores: Float32Array
+}
+
+function concatBigWigChunks(chunks: BigWigChunk[]): BigWigFeatureArrays {
+  const totalCount = chunks.reduce((n, chunk) => n + chunk.starts.length, 0)
+  return {
+    starts: concatTypedArray(
+      chunks.map(c => c.starts),
+      totalCount,
+      Int32Array,
+    ),
+    ends: concatTypedArray(
+      chunks.map(c => c.ends),
+      totalCount,
+      Int32Array,
+    ),
+    scores: concatTypedArray(
+      chunks.map(c => c.scores),
+      totalCount,
+      Float32Array,
+    ),
+    isSummary: false as const,
+  }
+}
+
+function concatSummaryChunks(chunks: SummaryChunk[]): SummaryFeatureArrays {
+  const totalCount = chunks.reduce((n, chunk) => n + chunk.starts.length, 0)
+  return {
+    starts: concatTypedArray(
+      chunks.map(c => c.starts),
+      totalCount,
+      Int32Array,
+    ),
+    ends: concatTypedArray(
+      chunks.map(c => c.ends),
+      totalCount,
+      Int32Array,
+    ),
+    scores: concatTypedArray(
+      chunks.map(c => c.scores),
+      totalCount,
+      Float32Array,
+    ),
+    minScores: concatTypedArray(
+      chunks.map(c => c.minScores),
+      totalCount,
+      Float32Array,
+    ),
+    maxScores: concatTypedArray(
+      chunks.map(c => c.maxScores),
+      totalCount,
+      Float32Array,
+    ),
+    isSummary: true as const,
+  }
+}
+
+// Pack per-region chunk lists into one backing set of typed arrays, recording
+// each region's slice boundary in regionOffsets. A single allocation per array
+// instead of one object-with-arrays per region. Regions are laid out in input
+// order; regionOffsets has length regionCount + 1.
+function concatBigWigChunksMulti(
+  chunksByRegion: BigWigChunk[][],
+): BigWigFeatureArraysMulti {
+  let totalCount = 0
+  for (const chunks of chunksByRegion) {
+    for (const chunk of chunks) {
+      totalCount += chunk.starts.length
+    }
+  }
+  const starts = new Int32Array(totalCount)
+  const ends = new Int32Array(totalCount)
+  const scores = new Float32Array(totalCount)
+  const regionOffsets = [0]
+  let offset = 0
+  for (const chunks of chunksByRegion) {
+    for (const chunk of chunks) {
+      starts.set(chunk.starts, offset)
+      ends.set(chunk.ends, offset)
+      scores.set(chunk.scores, offset)
+      offset += chunk.starts.length
+    }
+    regionOffsets.push(offset)
+  }
+  return { starts, ends, scores, regionOffsets, isSummary: false as const }
+}
+
+function concatSummaryChunksMulti(
+  chunksByRegion: SummaryChunk[][],
+): SummaryFeatureArraysMulti {
+  let totalCount = 0
+  for (const chunks of chunksByRegion) {
+    for (const chunk of chunks) {
+      totalCount += chunk.starts.length
+    }
+  }
+  const starts = new Int32Array(totalCount)
+  const ends = new Int32Array(totalCount)
+  const scores = new Float32Array(totalCount)
+  const minScores = new Float32Array(totalCount)
+  const maxScores = new Float32Array(totalCount)
+  const regionOffsets = [0]
+  let offset = 0
+  for (const chunks of chunksByRegion) {
+    for (const chunk of chunks) {
+      starts.set(chunk.starts, offset)
+      ends.set(chunk.ends, offset)
+      scores.set(chunk.scores, offset)
+      minScores.set(chunk.minScores, offset)
+      maxScores.set(chunk.maxScores, offset)
+      offset += chunk.starts.length
+    }
+    regionOffsets.push(offset)
+  }
+  return {
+    starts,
+    ends,
+    scores,
+    minScores,
+    maxScores,
+    regionOffsets,
+    isSummary: true as const,
+  }
+}
+
 function parseBlock(
   blockType: string,
   data: Uint8Array,
@@ -562,16 +708,15 @@ export class BlockView {
   // from different regions coalesce into a single read. Each block is tagged
   // with the region(s) whose coord filter applies when parsing it. Returns
   // features per region, aligned to the input order.
-  public async readWigDataMulti(
+  // Collect the R-tree blocks for every region and dedupe them by file offset:
+  // a block surfaced by multiple (overlapping) regions is fetched once but
+  // tagged with each region that wants it, so it gets parsed per region.
+  private async _collectBlocksMulti(
     regions: { refName: string; start: number; end: number }[],
-    opts: Options = {},
-  ): Promise<Feature[][]> {
-    const results: Feature[][] = regions.map(() => [])
+    opts: Options,
+  ): Promise<CollectedBlocksMulti> {
     const blockByOffset = new Map<number, Block>()
-    const tagsByOffset = new Map<
-      number,
-      { regionIndex: number; request: CoordRequest }[]
-    >()
+    const tagsByOffset = new Map<number, RegionTag[]>()
     for (let regionIndex = 0; regionIndex < regions.length; regionIndex++) {
       const { refName, start, end } = regions[regionIndex]!
       const collected = await this._collectBlocks(refName, start, end, opts)
@@ -588,6 +733,18 @@ export class BlockView {
         }
       }
     }
+    return { blockByOffset, tagsByOffset }
+  }
+
+  public async readWigDataMulti(
+    regions: { refName: string; start: number; end: number }[],
+    opts: Options = {},
+  ): Promise<Feature[][]> {
+    const results: Feature[][] = regions.map(() => [])
+    const { blockByOffset, tagsByOffset } = await this._collectBlocksMulti(
+      regions,
+      opts,
+    )
 
     const { blockType, uncompressBufSize } = this
     const { signal, onProgress } = opts
@@ -676,6 +833,98 @@ export class BlockView {
           scores: new Float32Array(0),
           isSummary: false as const,
         }
+  }
+
+  // Multi-region typed-array read. Same block dedupe/coalesce strategy as
+  // readWigDataMulti, but parses each block into typed-array chunks and packs
+  // all regions into one backing set of arrays (see *Multi return types). Unlike
+  // the single-region path it can't use the fused decompress+parse wasm call
+  // (that filters by one coord range), so it decompresses raw then parses each
+  // block per region in JS.
+  public async readWigDataAsArraysMulti(
+    regions: { refName: string; start: number; end: number }[],
+    opts: Options = {},
+  ): Promise<BigWigFeatureArraysMulti | SummaryFeatureArraysMulti> {
+    const collected = await this._collectBlocksMulti(regions, opts)
+    if (this.blockType === 'summary') {
+      const chunksByRegion = await this._readBlocksAsArraysMulti(
+        collected,
+        regions.length,
+        (data, request) => parseSummaryBlockAsArrays(data, request),
+        opts,
+      )
+      return concatSummaryChunksMulti(chunksByRegion)
+    }
+    const chunksByRegion = await this._readBlocksAsArraysMulti(
+      collected,
+      regions.length,
+      (data, request) => parseBigWigBlockAsArrays(data, request),
+      opts,
+    )
+    return concatBigWigChunksMulti(chunksByRegion)
+  }
+
+  // Fetch the deduped block union, decompress each group, and parse every block
+  // into a typed-array chunk for each region that tagged it. Empty chunks are
+  // dropped. Returns one chunk list per region, in input order.
+  private async _readBlocksAsArraysMulti<T extends BigWigChunk>(
+    collected: CollectedBlocksMulti,
+    regionCount: number,
+    parseChunk: (data: Uint8Array, request: CoordRequest) => T,
+    opts: Options,
+  ): Promise<T[][]> {
+    const { blockByOffset, tagsByOffset } = collected
+    const { signal, onProgress } = opts
+    const { uncompressBufSize } = this
+    const chunksByRegion: T[][] = Array.from({ length: regionCount }, () => [])
+    const parseInto = (resultData: Uint8Array, blockOffset: number) => {
+      const tags = tagsByOffset.get(blockOffset)
+      if (tags) {
+        for (const { regionIndex, request } of tags) {
+          const chunk = parseChunk(resultData, request)
+          if (chunk.starts.length > 0) {
+            chunksByRegion[regionIndex]!.push(chunk)
+          }
+        }
+      }
+    }
+
+    const blockGroups = groupBlocks([...blockByOffset.values()])
+    const report = blockProgress(blockGroups, onProgress)
+    for (const blockGroup of blockGroups) {
+      const data = await this.bbi.read(blockGroup.length, blockGroup.offset, {
+        signal,
+      })
+      report(blockGroup.length)
+      const groupOffset = blockGroup.offset
+      const subBlocks = blockGroup.blocks
+
+      if (uncompressBufSize > 0) {
+        const localBlocks = subBlocks.map(block => ({
+          offset: block.offset - groupOffset,
+          length: block.length,
+        }))
+        const { data: decompressedData, offsets } = await unzipBatch(
+          data,
+          localBlocks,
+          uncompressBufSize,
+        )
+        for (let i = 0; i < subBlocks.length; i++) {
+          const resultData = decompressedData.subarray(
+            offsets[i],
+            offsets[i + 1],
+          )
+          parseInto(resultData, subBlocks[i]!.offset)
+        }
+      } else {
+        for (const block of subBlocks) {
+          const start = block.offset - groupOffset
+          const resultData = data.subarray(start, start + block.length)
+          parseInto(resultData, block.offset)
+        }
+      }
+    }
+    return chunksByRegion
   }
 
   public async readFeatures(
@@ -806,25 +1055,7 @@ export class BlockView {
       chunk => chunk.starts.length,
       opts.onProgress,
     )
-    const totalCount = chunks.reduce((n, chunk) => n + chunk.starts.length, 0)
-    return {
-      starts: concatTypedArray(
-        chunks.map(c => c.starts),
-        totalCount,
-        Int32Array,
-      ),
-      ends: concatTypedArray(
-        chunks.map(c => c.ends),
-        totalCount,
-        Int32Array,
-      ),
-      scores: concatTypedArray(
-        chunks.map(c => c.scores),
-        totalCount,
-        Float32Array,
-      ),
-      isSummary: false as const,
-    }
+    return concatBigWigChunks(chunks)
   }
 
   private async _readSummaryFeaturesAsArrays(
@@ -848,34 +1079,6 @@ export class BlockView {
       chunk => chunk.starts.length,
       opts.onProgress,
     )
-    const totalCount = chunks.reduce((n, chunk) => n + chunk.starts.length, 0)
-    return {
-      starts: concatTypedArray(
-        chunks.map(c => c.starts),
-        totalCount,
-        Int32Array,
-      ),
-      ends: concatTypedArray(
-        chunks.map(c => c.ends),
-        totalCount,
-        Int32Array,
-      ),
-      scores: concatTypedArray(
-        chunks.map(c => c.scores),
-        totalCount,
-        Float32Array,
-      ),
-      minScores: concatTypedArray(
-        chunks.map(c => c.minScores),
-        totalCount,
-        Float32Array,
-      ),
-      maxScores: concatTypedArray(
-        chunks.map(c => c.maxScores),
-        totalCount,
-        Float32Array,
-      ),
-      isSummary: true as const,
-    }
+    return concatSummaryChunks(chunks)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { parseBigWig } from './parse-bigwig.ts'
 export { ArrayFeatureView, BigWigFeature } from './array-feature-view.ts'
 export type {
   BigWigFeatureArrays,
+  BigWigFeatureArraysMulti,
   BigWigHeader,
   BigWigHeaderWithRefNames,
   Feature,
@@ -13,5 +14,6 @@ export type {
   RequestOptions,
   Statistics,
   SummaryFeatureArrays,
+  SummaryFeatureArraysMulti,
   ZoomLevel,
 } from './types.ts'

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,3 +124,20 @@ export interface SummaryFeatureArrays {
   maxScores: Float32Array
   isSummary: true
 }
+
+/**
+ * Multi-region typed-array result. Rather than one object per region, all
+ * regions share one backing set of typed arrays; `regionOffsets[i]..
+ * regionOffsets[i + 1]` is the half-open slice belonging to region `i`. Pull a
+ * single region out with e.g. `starts.subarray(regionOffsets[i],
+ * regionOffsets[i + 1])` — no copy. `regionOffsets` has length `regions.length
+ * + 1`.
+ */
+export interface BigWigFeatureArraysMulti extends BigWigFeatureArrays {
+  regionOffsets: number[]
+}
+
+/** Multi-region counterpart of {@link SummaryFeatureArrays}; see {@link BigWigFeatureArraysMulti} for the `regionOffsets` layout. */
+export interface SummaryFeatureArraysMulti extends SummaryFeatureArrays {
+  regionOffsets: number[]
+}

--- a/src/unzip.ts
+++ b/src/unzip.ts
@@ -67,4 +67,9 @@ export async function decompressAndParseSummaryBlocks(
   )
 }
 
-export type { BigWigFeatureArrays, SummaryFeatureArrays } from './types.ts'
+export type {
+  BigWigFeatureArrays,
+  BigWigFeatureArraysMulti,
+  SummaryFeatureArrays,
+  SummaryFeatureArraysMulti,
+} from './types.ts'

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -3,7 +3,10 @@ import { expect, test } from 'vitest'
 import { BigWig } from '../src/index.ts'
 
 class BufferFilehandle {
-  constructor(private buf: Uint8Array) {}
+  private buf: Uint8Array
+  constructor(buf: Uint8Array) {
+    this.buf = buf
+  }
   read(length: number, position: number) {
     return Promise.resolve(this.buf.subarray(position, position + length))
   }

--- a/test/multi.test.ts
+++ b/test/multi.test.ts
@@ -11,7 +11,10 @@ class CountingFile {
   reads = 0
   bytes = 0
   offsets: number[] = []
-  constructor(private inner: GenericFilehandle) {}
+  private inner: GenericFilehandle
+  constructor(inner: GenericFilehandle) {
+    this.inner = inner
+  }
   read(length: number, position: number, opts?: Record<string, unknown>) {
     this.reads++
     this.bytes += length

--- a/test/multi.test.ts
+++ b/test/multi.test.ts
@@ -161,3 +161,86 @@ test('getFeaturesMulti handles unknown refName and empty input', async () => {
   expect(res[1]).toStrictEqual([])
   expect(await bw.getFeaturesMulti([], { scale })).toStrictEqual([])
 })
+
+test('getFeaturesAsArraysMulti matches per-region getFeaturesAsArrays', async () => {
+  const bw = new BigWig({ path: 'test/data/cDC.bw' })
+  const regions = [
+    { refName: 'chr1', start: 1_000_000, end: 3_000_000 },
+    { refName: 'chr1', start: 2_000_000, end: 4_000_000 }, // overlaps previous
+    { refName: 'chr2', start: 0, end: 5_000_000 },
+  ]
+  const scale = 1 / 5000
+
+  const multi = await bw.getFeaturesAsArraysMulti(regions, { scale })
+  expect(multi.regionOffsets.length).toBe(regions.length + 1)
+  expect(multi.regionOffsets[0]).toBe(0)
+  expect(multi.regionOffsets.at(-1)).toBe(multi.starts.length)
+
+  for (let i = 0; i < regions.length; i++) {
+    const r = regions[i]!
+    const truth = await bw.getFeaturesAsArrays(r.refName, r.start, r.end, {
+      scale,
+    })
+    const lo = multi.regionOffsets[i]!
+    const hi = multi.regionOffsets[i + 1]!
+    expect(Array.from(multi.starts.subarray(lo, hi))).toEqual(
+      Array.from(truth.starts),
+    )
+    expect(Array.from(multi.ends.subarray(lo, hi))).toEqual(
+      Array.from(truth.ends),
+    )
+    expect(Array.from(multi.scores.subarray(lo, hi))).toEqual(
+      Array.from(truth.scores),
+    )
+  }
+})
+
+test('getFeaturesAsArraysMulti returns summary arrays at zoomed scale', async () => {
+  const bw = new BigWig({ path: 'test/data/cDC.bw' })
+  const regions = [
+    { refName: 'chr1', start: 0, end: 60_000_000 },
+    { refName: 'chr2', start: 0, end: 60_000_000 },
+  ]
+  const scale = 1000 / 250_000_000
+
+  const multi = await bw.getFeaturesAsArraysMulti(regions, { scale })
+  expect(multi.isSummary).toBe(true)
+  if (multi.isSummary) {
+    for (let i = 0; i < regions.length; i++) {
+      const r = regions[i]!
+      const truth = await bw.getFeaturesAsArrays(r.refName, r.start, r.end, {
+        scale,
+      })
+      const lo = multi.regionOffsets[i]!
+      const hi = multi.regionOffsets[i + 1]!
+      expect(Array.from(multi.starts.subarray(lo, hi))).toEqual(
+        Array.from(truth.starts),
+      )
+      expect(Array.from(multi.minScores.subarray(lo, hi))).toEqual(
+        Array.from(truth.isSummary ? truth.minScores : []),
+      )
+      expect(Array.from(multi.maxScores.subarray(lo, hi))).toEqual(
+        Array.from(truth.isSummary ? truth.maxScores : []),
+      )
+    }
+  }
+})
+
+test('getFeaturesAsArraysMulti handles unknown refName and empty input', async () => {
+  const bw = new BigWig({ path: 'test/data/cDC.bw' })
+  const scale = 1 / 1000
+  const res = await bw.getFeaturesAsArraysMulti(
+    [
+      { refName: 'chr1', start: 0, end: 100000 },
+      { refName: 'nonexistent', start: 0, end: 100 },
+    ],
+    { scale },
+  )
+  expect(res.regionOffsets.length).toBe(3)
+  // the unknown region's slice is empty
+  expect(res.regionOffsets[2]! - res.regionOffsets[1]!).toBe(0)
+
+  const empty = await bw.getFeaturesAsArraysMulti([], { scale })
+  expect(empty.regionOffsets).toEqual([0])
+  expect(empty.starts.length).toBe(0)
+})


### PR DESCRIPTION
## Summary

Adds `getFeaturesAsArraysMulti`, the multi-region counterpart of `getFeaturesAsArrays`. It combines the block-coalescing of `getFeaturesMulti` with the typed-array output of `getFeaturesAsArrays`.

```ts
bw.getFeaturesAsArraysMulti(
  regions: { refName: string; start: number; end: number }[],
  opts?: RequestOptions2,
): Promise<BigWigFeatureArraysMulti | SummaryFeatureArraysMulti>
```

## Data-efficient return shape

Rather than returning `N` separate objects (N×3 array allocations), all regions share **one backing set of typed arrays** plus a `regionOffsets: number[]` index. Region `i`'s slice is `regionOffsets[i]..regionOffsets[i + 1]` — extractable copy-free:

```ts
const r = await bw.getFeaturesAsArraysMulti(regions, { scale })
const starts0 = r.starts.subarray(r.regionOffsets[0], r.regionOffsets[1])
```

One allocation per array instead of one object-with-arrays per region.

## Implementation

- `_collectBlocksMulti` — extracted the shared collect-and-dedupe-by-offset logic (a block surfaced by overlapping regions is fetched once, tagged per region), now used by both `readWigDataMulti` and the new path.
- `_readBlocksAsArraysMulti` — fetches the coalesced block union, decompresses each group, parses each block into a typed-array chunk per region that tagged it. Uses `unzipBatch` + JS parse rather than the fused decompress+parse wasm call (that filters by a single coord range and can't serve multiple regions from one shared block).
- `concatBigWigChunksMulti` / `concatSummaryChunksMulti` — pack per-region chunks into the single backing arrays and build `regionOffsets`.
- Refactored the existing single-region `_readBigWigFeaturesAsArrays`/`_readSummaryFeaturesAsArrays` onto shared `concatBigWigChunks`/`concatSummaryChunks` helpers, removing duplicated concat code.
- New exported types `BigWigFeatureArraysMulti` / `SummaryFeatureArraysMulti`.

## Testing

47 tests pass (3 new): base-resolution vs per-region truth incl. overlapping regions, summary/zoomed scale, and unknown-refName/empty-input edge cases. Lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)