### PR TITLE
Emit the .slice() rationale from build-wasm.sh so it survives regeneration

### DIFF
--- a/crate/build-wasm.sh
+++ b/crate/build-wasm.sh
@@ -42,3 +42,16 @@ else
   echo "wasm-bindgen changed getStringFromWasm0; re-check the resizable-buffer patch" >&2
   exit 1
 fi
+
+# Leave the reason beside the stray .slice(), for whoever opens the generated
+# file and wonders why it is there. Emitted here for the same reason the patch
+# itself is: this file is rewritten by wasm-bindgen above, so a comment added to
+# src/wasm by hand is gone on the next build -- which is exactly what happened
+# to the one b9d1007 wrote, leaving a phantom 14-line deletion in every rebuild
+# since. webpack carries it into the inlined bundle (production mode, but
+# `optimization.minimize` is off, so comments survive).
+if ! grep -qF '// .slice() is load-bearing' "$glue"; then
+  perl -pi -e 'print "    // .slice() is load-bearing: getUint8ArrayMemory0() is a view over\n    // WebAssembly.Memory, whose buffer is a RESIZABLE ArrayBuffer, and\n    // TextDecoder.decode rejects those in browsers. Without the copy every\n    // string leaving Rust throws -- and the only strings this crate returns\n    // are error messages, so the module could not report its own errors.\n    // Emitted by crate/build-wasm.sh; an edit here is lost on the next build.\n" if /\Qsubarray(ptr, ptr + len).slice()\E/;' "$glue"
+  grep -qF '// .slice() is load-bearing' "$glue" || { echo "annotation did not apply to $glue" >&2; exit 1; }
+  echo "annotated the string-decode copy"
+fi

--- a/src/wasm/inflate-wasm-inlined.js
+++ b/src/wasm/inflate-wasm-inlined.js
@@ -348,11 +348,10 @@ function decodeText(ptr, len) {
     }
     // .slice() is load-bearing: getUint8ArrayMemory0() is a view over
     // WebAssembly.Memory, whose buffer is a RESIZABLE ArrayBuffer, and
-    // TextDecoder.decode rejects those in browsers. Without the copy this
-    // throws for every string leaving Rust -- which is every error message,
-    // so the module could not report its own errors. The Vec<u8> return path
-    // already slices; this is the same rule for strings. See
-    // bgzf-filehandle agent-docs/adr/0002.
+    // TextDecoder.decode rejects those in browsers. Without the copy every
+    // string leaving Rust throws -- and the only strings this crate returns
+    // are error messages, so the module could not report its own errors.
+    // Emitted by crate/build-wasm.sh; an edit here is lost on the next build.
     return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len).slice());
 }
 

--- a/src/wasm/inflate_wasm_bg.js
+++ b/src/wasm/inflate_wasm_bg.js
@@ -244,11 +244,10 @@ function decodeText(ptr, len) {
     }
     // .slice() is load-bearing: getUint8ArrayMemory0() is a view over
     // WebAssembly.Memory, whose buffer is a RESIZABLE ArrayBuffer, and
-    // TextDecoder.decode rejects those in browsers. Without the copy this
-    // throws for every string leaving Rust -- which is every error message,
-    // so the module could not report its own errors. The Vec<u8> return path
-    // already slices; this is the same rule for strings. See
-    // bgzf-filehandle agent-docs/adr/0002.
+    // TextDecoder.decode rejects those in browsers. Without the copy every
+    // string leaving Rust throws -- and the only strings this crate returns
+    // are error messages, so the module could not report its own errors.
+    // Emitted by crate/build-wasm.sh; an edit here is lost on the next build.
     return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len).slice());
 }
 


### PR DESCRIPTION
`b9d1007` put the `.slice()` patch in `crate/build-wasm.sh` precisely because
`src/wasm` is regenerated — then hand-wrote the comment explaining it *into the
generated file*, where the next `wasm-bindgen` run wiped it.

Every build since has left a phantom 14-line deletion in the working tree. Not
hypothetical: that dirty tree is what blocked a release attempt earlier, on
files nobody had edited.

The comment is now emitted from the same place as the patch, guarded so it
can't double-apply, and failing loudly if it doesn't take — matching how the
`.slice()` substitution above it already behaves.

## Verification

Ran `pnpm build:wasm` **twice**. The resulting diff is byte-identical both
times, and `inflate_wasm_bg.wasm` doesn't change at all (the Rust build is
reproducible), so a rebuild now touches only the comment it just wrote.

webpack carries it into the inlined bundle — production mode, but
`optimization.minimize` is off, which is why the old hand-written comment
appeared in both files too.

## Scope

Originally opened with a second commit narrowing the constructor to a read-only
`BBIFilehandle` type. Dropped at the maintainer's call: no gmod package calls
`.stat()` (checked all six), so `GenericFilehandle` being over-demanding is a
family-wide question rather than a bbi-js one — and narrowing it here alone
would have made bbi-js the only package in the group with a different filehandle
contract. Staying with `GenericFilehandle`.

## Test plan

`pnpm lint`, `pnpm typecheck`, `pnpm format:check`, `pnpm test` (82 tests, 10
files) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
